### PR TITLE
Add a swap chain id

### DIFF
--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -5,6 +5,7 @@
 use crate::webgl_thread::{WebGLThread, WebGLThreadInit};
 use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLSender, WebGLThreads};
 use canvas_traits::webgl::{WebVRRenderHandler, webgl_channel};
+use canvas_traits::webgl::SwapChainId;
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl;
@@ -112,7 +113,7 @@ struct WebGLExternalImages {
     context: Rc<RefCell<Context>>,
     webrender_gl: Rc<dyn gl::Gl>,
     swap_chains: SwapChains,
-    locked_front_buffers: FnvHashMap<WebGLContextId, SurfaceTexture>,
+    locked_front_buffers: FnvHashMap<SwapChainId, SurfaceTexture>,
     sendable: SendableWebGLExternalImages,
 }
 
@@ -134,50 +135,36 @@ impl WebGLExternalImages {
     }
 }
 
-impl WebrenderExternalImageApi for WebGLExternalImages {
-    fn lock(&mut self, id: u64) -> (u32, Size2D<i32>) {
-        let id = WebGLContextId(id);
-
+impl WebGLExternalImages {
+    fn lock_swap_chain(&mut self, id: SwapChainId) -> Option<(u32, Size2D<i32>)> {
         let mut swap_chains = self.swap_chains.lock();
-        let mut front_buffer = None;
-        if let Some(ref mut swap_chain) = swap_chains.get_mut(&id) {
-            front_buffer = swap_chain.pending_surface.take();
-            if front_buffer.is_none() {
-                println!("*** no surface ready, presenting last one");
-                front_buffer = swap_chain.presented_surfaces.pop();
-            }
-        }
+        let swap_chain = swap_chains.get_mut(&id)?;
+        let front_buffer = swap_chain.pending_surface.take().or_else(|| {
+            println!("*** no surface ready, presenting last one");
+            swap_chain.presented_surfaces.pop()
+        })?;
 
-        let (mut gl_texture, mut size) = (0, Size2D::new(0, 0));
-        if let Some(front_buffer) = front_buffer {
-            let mut context = self.context.borrow_mut();
-            size = front_buffer.size();
-            let front_buffer_texture = self.device
-                                           .create_surface_texture(&mut *context, front_buffer)
-                                           .unwrap();
-            gl_texture = front_buffer_texture.gl_texture();
-            self.locked_front_buffers.insert(id, front_buffer_texture);
-        }
+        let mut context = self.context.borrow_mut();
+        let size = front_buffer.size();
+        let front_buffer_texture = self.device
+                                       .create_surface_texture(&mut *context, front_buffer)
+                                       .unwrap();
+        let gl_texture = front_buffer_texture.gl_texture();
 
-        (gl_texture, size)
+        self.locked_front_buffers.insert(id, front_buffer_texture);
+
+        Some((gl_texture, size))
     }
 
-    fn unlock(&mut self, id: u64) {
-        self.sendable.unlock(id as usize);
-
-        let id = WebGLContextId(id);
-        let locked_front_buffer = match self.locked_front_buffers.remove(&id) {
-            None => return,
-            Some(locked_front_buffer) => locked_front_buffer,
-        };
-
+    fn unlock_swap_chain(&mut self, id: SwapChainId) -> Option<()> {
+        let locked_front_buffer = self.locked_front_buffers.remove(&id)?;
         let mut context = self.context.borrow_mut();
         let locked_front_buffer = self.device
                                       .destroy_surface_texture(&mut *context, locked_front_buffer)
                                       .unwrap();
 
         self.swap_chains.push_presented_surface(id, locked_front_buffer);
-
+        Some(())
         /*
         let mut front_buffer_slot = self.swap_chains.get(id);
         let mut locked_front_buffer_slot = front_buffer_slot.lock();
@@ -192,9 +179,21 @@ impl WebrenderExternalImageApi for WebGLExternalImages {
     }
 }
 
+impl WebrenderExternalImageApi for WebGLExternalImages {
+    fn lock(&mut self, id: u64) -> (u32, Size2D<i32>) {
+        let id = SwapChainId::Context(WebGLContextId(id));
+        self.lock_swap_chain(id).unwrap_or_default()
+    }
+
+    fn unlock(&mut self, id: u64) {
+        let id = SwapChainId::Context(WebGLContextId(id));
+        self.unlock_swap_chain(id);
+    }
+}
+
 #[derive(Clone)]
 pub struct SwapChains {
-    table: Arc<Mutex<FnvHashMap<WebGLContextId, SwapChain>>>,
+    table: Arc<Mutex<FnvHashMap<SwapChainId, SwapChain>>>,
 }
 
 pub(crate) struct SwapChain {
@@ -209,9 +208,9 @@ impl SwapChains {
         }
     }
 
-    fn push_presented_surface(&self, context_id: WebGLContextId, surface: Surface) {
+    fn push_presented_surface(&self, swap_id: SwapChainId, surface: Surface) {
         let mut table = self.lock();
-        match table.entry(context_id) {
+        match table.entry(swap_id) {
             Entry::Vacant(vacant_entry) => {
                 vacant_entry.insert(SwapChain {
                     pending_surface: None,
@@ -224,7 +223,7 @@ impl SwapChains {
         }
     }
 
-    pub(crate) fn lock(&self) -> MutexGuard<FnvHashMap<WebGLContextId, SwapChain>> {
+    pub(crate) fn lock(&self) -> MutexGuard<FnvHashMap<SwapChainId, SwapChain>> {
         self.table.lock().unwrap()
     }
 }

--- a/components/canvas/webgl_mode/mod.rs
+++ b/components/canvas/webgl_mode/mod.rs
@@ -4,5 +4,6 @@
 
 mod inprocess;
 
-pub use self::inprocess::{SwapChains, WebGLComm};
+pub use self::inprocess::WebGLComm;
 pub(crate) use self::inprocess::SwapChain;
+pub(crate) use self::inprocess::SwapChains;

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -14,6 +14,7 @@ use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsg, WebGLMsgSender, WebGLPr
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
 use canvas_traits::webgl::{WebGLShaderId, WebGLTextureId, WebGLVersion, WebGLVertexArrayId};
 use canvas_traits::webgl::{WebVRCommand, WebVRRenderHandler, YAxisTreatment};
+use canvas_traits::webgl::SwapChainId;
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl::{self, Gl, GlFns};
@@ -85,7 +86,7 @@ pub(crate) struct WebGLThread {
     receiver: WebGLReceiver<WebGLMsg>,
     /// The receiver that should be used to send WebGL messages for processing.
     sender: WebGLSender<WebGLMsg>,
-    /// The front buffer for each WebGL context ID.
+    /// The front buffer for each swap chain ID.
     swap_chains: SwapChains,
 }
 
@@ -253,8 +254,8 @@ impl WebGLThread {
             WebGLMsg::UpdateWebRenderImage(ctx_id, sender) => {
                 self.handle_update_wr_image(ctx_id, sender);
             },
-            WebGLMsg::SwapBuffers(ctx_id) => {
-                self.handle_swap_buffers(ctx_id);
+            WebGLMsg::SwapBuffers(swap_id) => {
+                self.handle_swap_buffers(swap_id);
             },
             WebGLMsg::DOMToTextureCommand(command) => {
                 self.handle_dom_to_texture(command);
@@ -391,12 +392,6 @@ impl WebGLThread {
         let new_surface = self.device.create_surface(&data.ctx, &size.to_i32()).unwrap();
         let old_surface = self.device.replace_context_surface(&mut data.ctx, new_surface).unwrap();
         self.device.destroy_surface(&mut data.ctx, old_surface).unwrap();
-        let new_surface = self.device.create_surface(&data.ctx, &size.to_i32()).unwrap();
-        let old_surface = self.device.replace_context_surface(&mut data.ctx, new_surface).unwrap();
-        self.device.destroy_surface(&mut data.ctx, old_surface).unwrap();
-
-        let framebuffer = self.device.context_surface_framebuffer_object(&data.ctx).unwrap();
-        data.gl.bind_framebuffer(gl::FRAMEBUFFER, framebuffer);
 
         // Update WR image if needed. Resize image updates are only required for SharedTexture mode.
         // Readback mode already updates the image every frame to send the raw pixels.
@@ -444,7 +439,8 @@ impl WebGLThread {
         };
 
         // Destroy all the surfaces
-        if let Some(swap_chain) = self.swap_chains.lock().remove(&context_id) {
+        let swap_id = SwapChainId::Context(context_id);
+        if let Some(swap_chain) = self.swap_chains.lock().remove(&swap_id) {
             for surface in swap_chain.pending_surface {
                 self.device.destroy_surface(&mut data.ctx, surface).unwrap();
             }
@@ -471,7 +467,7 @@ impl WebGLThread {
         sender: WebGLSender<webrender_api::ImageKey>,
     ) {
         println!("handle_update_wr_image()");
-        self.handle_swap_buffers(context_id);
+        self.handle_swap_buffers(SwapChainId::Context(context_id));
 
         let data = Self::make_current_if_needed_mut(
             &self.device,
@@ -506,8 +502,9 @@ impl WebGLThread {
         sender.send(image_key).unwrap();
     }
 
-    fn handle_swap_buffers(&mut self, context_id: WebGLContextId) {
+    fn handle_swap_buffers(&mut self, swap_id: SwapChainId) {
         println!("handle_swap_buffers()");
+        let context_id = swap_id.context_id();
         let data = Self::make_current_if_needed_mut(
             &self.device,
             context_id,
@@ -522,7 +519,7 @@ impl WebGLThread {
 
             // Fetch a new back buffer.
             let mut new_back_buffer = None;
-            if let Some(ref mut swap_chain) = swap_chains.get_mut(&context_id) {
+            if let Some(ref mut swap_chain) = swap_chains.get_mut(&swap_id) {
                 for presented_surface_index in 0..swap_chain.presented_surfaces.len() {
                     if size == swap_chain.presented_surfaces[presented_surface_index].size() {
                         new_back_buffer = Some(swap_chain.presented_surfaces
@@ -544,13 +541,12 @@ impl WebGLThread {
             println!("... new back buffer will become {:?}", new_back_buffer.id());
 
             // Swap the buffers.
-            let new_front_buffer = self.device
-                                       .replace_context_surface(&mut data.ctx, new_back_buffer)
+            let new_front_buffer = self.device.replace_context_surface(&mut data.ctx, new_back_buffer)
                                        .expect("Where's the new front buffer?");
             println!("... front buffer is now {:?}", new_front_buffer.id());
 
             // Hand the new front buffer to the compositor.
-            match swap_chains.entry(context_id) {
+            match swap_chains.entry(swap_id) {
                 Entry::Occupied(mut occupied_entry) => {
                     let mut swap_chain = occupied_entry.get_mut();
                     if let Some(old_front_buffer) = mem::replace(&mut swap_chain.pending_surface,

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -103,7 +103,7 @@ pub enum WebGLMsg {
     /// Commands used for the DOMToTexture feature.
     DOMToTextureCommand(DOMToTextureCommand),
     /// Performs a buffer swap.
-    SwapBuffers(WebGLContextId),
+    SwapBuffers(SwapChainId),
     /// Frees all resources and closes the thread.
     Exit,
 }
@@ -205,7 +205,8 @@ impl WebGLMsgSender {
 
     #[inline]
     pub fn send_swap_buffers(&self) -> WebGLSendResult {
-        self.sender.send(WebGLMsg::SwapBuffers(self.ctx_id))
+        let swap_id = SwapChainId::Context(self.ctx_id);
+        self.sender.send(WebGLMsg::SwapBuffers(swap_id))
     }
 
     pub fn send_dom_to_texture(&self, command: DOMToTextureCommand) -> WebGLSendResult {
@@ -533,6 +534,20 @@ define_resource_id!(WebGLVertexArrayId);
     Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct WebGLContextId(pub u64);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum SwapChainId {
+    Context(WebGLContextId),
+    // TODO: support opaque framebuffers
+}
+
+impl SwapChainId {
+    pub fn context_id(&self) -> WebGLContextId {
+        match *self {
+	    SwapChainId::Context(id) => id,
+	}
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum WebGLError {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -105,7 +105,7 @@ use backtrace::Backtrace;
 use bluetooth_traits::BluetoothRequest;
 use canvas::canvas_paint_thread::CanvasPaintThread;
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
-use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads};
+use canvas_traits::webgl::{SwapChainId, WebGLContextId, WebGLMsg, WebGLThreads};
 use compositing::compositor_thread::CompositorProxy;
 use compositing::compositor_thread::Msg as ToCompositorMsg;
 use compositing::SendableFrameTree;
@@ -2130,7 +2130,8 @@ where
     fn handle_swap_webgl_buffers_msg(&mut self, context_ids: Vec<WebGLContextId>) {
         if let Some(ref webgl_threads) = self.webgl_threads {
             for context_id in context_ids {
-                if webgl_threads.0.send(WebGLMsg::SwapBuffers(context_id)).is_err() {
+                let swap_id = SwapChainId::Context(context_id);
+                if webgl_threads.0.send(WebGLMsg::SwapBuffers(swap_id)).is_err() {
                     warn!("Failed to send WebGL buffer swap message!")
                 }
             }


### PR DESCRIPTION
This makes swap chains indexed by a swap chain id rather than a context id. The next step is to add opaque framebuffer ids, and allow swap chain ids to be either.