### PR TITLE
Use the swap-chains crate for swap chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,8 @@ dependencies = [
  "raqote 0.6.1-alpha.0 (git+https://github.com/jrmuizel/raqote)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
- "surfman 0.23.0",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
+ "swap-chains 0.1.0 (git+https://github.com/asajeffrey/swap-chains)",
  "webrender 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_traits 0.0.1",
@@ -645,7 +646,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
- "surfman 0.23.0",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.60.0 (git+https://github.com/servo/webrender)",
@@ -2602,7 +2603,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style 0.0.1",
  "style_traits 0.0.1",
- "surfman 0.23.0",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
  "webdriver_server 0.0.1",
  "webrender 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
@@ -4152,7 +4153,7 @@ dependencies = [
  "rust-webvr 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media 0.1.0 (git+https://github.com/servo/media)",
  "sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "surfman 0.23.0",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "webxr 0.0.1 (git+https://github.com/servo/webxr)",
  "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
@@ -4527,7 +4528,7 @@ dependencies = [
  "libservo 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media 0.1.0 (git+https://github.com/servo/media)",
- "surfman 0.23.0",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4789,6 +4790,7 @@ dependencies = [
 [[package]]
 name = "surfman"
 version = "0.23.0"
+source = "git+https://github.com/pcwalton/surfman#6b32ed74d67e31097532f7b4071e9344582a0640"
 dependencies = [
  "android-ndk-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4818,6 +4820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "sw-composite"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "swap-chains"
+version = "0.1.0"
+source = "git+https://github.com/asajeffrey/swap-chains#020b9b8e1817ceb29da240b84411da1db3b0d372"
+dependencies = [
+ "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "surfman 0.23.0 (git+https://github.com/pcwalton/surfman)",
+]
 
 [[package]]
 name = "swapper"
@@ -6167,8 +6180,10 @@ dependencies = [
 "checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum surfman 0.23.0 (git+https://github.com/pcwalton/surfman)" = "<none>"
 "checksum svg_fmt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c666f0fed8e1e20e057af770af9077d72f3d5a33157b8537c1475dd8ffd6d32b"
 "checksum sw-composite 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5eba1755094da86216f071f7a28b0453345c3e6e558ea2fd7821c55eef8fb9b2"
+"checksum swap-chains 0.1.0 (git+https://github.com/asajeffrey/swap-chains)" = "<none>"
 "checksum swapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e454d048db5527d000bfddb77bd072bbf3a1e2ae785f16d9bd116e07c2ab45eb"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,3 @@ cmake = { git = "https://github.com/alexcrichton/cmake-rs" }
 
 core-foundation = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }
 io-surface = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }
-[patch."https://github.com/pcwalton/surfman"]
-surfman = { path = "../surfman/surfman" }

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -38,6 +38,7 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webrender_traits = {path = "../webrender_traits"}
 webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}
 surfman = { git = "https://github.com/pcwalton/surfman" }
+swap-chains =  { git = "https://github.com/asajeffrey/swap-chains" }
 
 [target.x86_64-apple-darwin.dependencies]
 io-surface = "0.11.1"

--- a/components/canvas/webgl_mode/mod.rs
+++ b/components/canvas/webgl_mode/mod.rs
@@ -4,5 +4,4 @@
 
 mod inprocess;
 
-pub use self::inprocess::{SwapChains, WebGLComm};
-pub(crate) use self::inprocess::{FrontSurface, SwapChain};
+pub use self::inprocess::WebGLComm;


### PR DESCRIPTION
This PR moves the swap chain logic out of servo and into its own crate. This refactoring means that the webxr crate can depend on swap chains, which otherwise it couldn't.